### PR TITLE
Filter null thread info

### DIFF
--- a/hotspot/src/main/kotlin/dev/evo/prometheus/jvm/jvm.kt
+++ b/hotspot/src/main/kotlin/dev/evo/prometheus/jvm/jvm.kt
@@ -155,7 +155,7 @@ class JvmThreadMetrics : PrometheusMetrics() {
         deadlockedMonitor.set(threadBean.findMonitorDeadlockedThreads()?.size?.toLong() ?: 0L)
         val allThreadIds = threadBean.allThreadIds
         val threadStateCounts = HashMap<Thread.State, Int>(6)
-        threadBean.getThreadInfo(allThreadIds).forEach {
+        threadBean.getThreadInfo(allThreadIds).filterNotNull().forEach {
             threadStateCounts.compute(it.threadState) { _, oldCount ->
                 (oldCount ?: 0) + 1
             }


### PR DESCRIPTION
Fix for an error that came out.

We found that in rare cases a thread got lost and the thread info contained null values causing errors.